### PR TITLE
Updated Termux with tested instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This guide will instruct you on how to SSH into your Raspiblitz over TOR using a
 ----------------------------------------------
 
 **Connect Through Mobile Device**
+
 For **JuiceSSH**
   1. Install and launch Orbot
   2. Enable 'VPN mode' and connect to TOR
@@ -60,7 +61,7 @@ For **Termux**: Run the following commands
   pkg install openssh tor proxychains-ng termux-services
   ```
   2. Restart Termux
-  3. Enable tor service and SSH into your raspiblitz.
+  3. Enable tor service and SSH into your raspiblitz
   ```
   sv-enable tor
   proxychains4 ssh admin@youraddress.onion

--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ This guide will instruct you on how to SSH into your Raspiblitz over TOR using a
 ----------------------------------------------
 
 **Connect Through Mobile Device**
-1. Install and launch Orbot
-2. Enable 'VPN mode' and connect to TOR
-3. Install and launch your SSH app
-4. SSH into your raspiblitz
+For **JuiceSSH**
+  1. Install and launch Orbot
+  2. Enable 'VPN mode' and connect to TOR
+  3. Install and launch your SSH app
+  4. SSH into your raspiblitz
 
-  For JuiceSSH: Add a new connection
+  In JuiceSSH: Add a new connection
   ```
    - Type: SSH
    - Address: youraddress.onion (from step 6)
@@ -53,10 +54,18 @@ This guide will instruct you on how to SSH into your Raspiblitz over TOR using a
       Password: 'Your Raspiblitz Password A'
    - Port: 22
   ```
-  For Termux: Run the following commands
+For **Termux**: Run the following commands
+  1. Install necessary packages
   ```
-  pkg install openssh
-  ssh admin@youraddress.onion
+  pkg install openssh tor proxychains-ng termux-services
   ```
-5. You should now be connected to your raspiblitz node!
+  2. Restart Termux
+  3. Enable tor service and SSH into your raspiblitz.
+  ```
+  sv-enable tor
+  proxychains4 ssh admin@youraddress.onion
+  ```
+  *Note: if you use Orbot VPN system-wide you need to deselect Termux.*
+  
+You should now be connected to your raspiblitz node!
 


### PR DESCRIPTION
Simple Orbot + Termux seems to not work any longer (was the previous version tested?). After reading from here https://wiki.termux.com/wiki/Bypassing_NAT I managed to SSH to the Raspiblitz. Tested on Android 12.0 (no root).